### PR TITLE
Fix D01.P2.extract_numbers/3

### DIFF
--- a/lib/mix/tasks/d01/p2.ex
+++ b/lib/mix/tasks/d01/p2.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.D01.P2 do
         extract_numbers(tail, current_word <> head, digits)
 
       true ->
-        extract_numbers(tail, head, digits)
+        extract_numbers(tail, String.slice(current_word, 1..-1) <> head, digits)
     end
   end
 


### PR DESCRIPTION
As @tommyblue pointed out we are parsing some strings incorrectly, for example
```elixir
alias Mix.Tasks.D01.P2
"eight53twonine" |> String.codepoints() |> P2.extract_numbers()
# => [8, 5, 3, 2]
```

The issue here is that for some iteration we have the following state in `P2.extract_number/3`:
```
codepoints: ["o", "n", "i", "n", "e"] => head: "o", tail: ["n", "i", "n", "e"]
current_word: "tw"
```
now in this situation we have that `current_word <> head in @w_numbers` yields `true` and the next state will be:
```
codepoints: ["o", "n", "i", "n", "e"] => head: "o", tail: ["n", "i", "n", "e"]
current_word: ""
```
At this point we have that `is_prefix?(current_word <> head)` is `true` (since `current_word <> head == "o"`) and this lead us to
```
codepoints: ["n", "i", "n", "e"] => head: "n", tail: ["i", "n", "e"]
current_word: "o"
```
Again `is_prefix?(current_word <> head)` is `true` (since `current_word <> head == "on"`), then we have
```
codepoints: ["i", "n", "e"] => head: "i", tail: ["n", "e"]
current_word: "on"
```
Now `"oni"` is nothing, so we end up in the default branch and the next state is
```
codepoints: ["n", "e"] => head: "n", tail: ["e"]
current_word: "i"
```
That will never match `"nine"` because we lost the `n`. The reason this happened is because when something that is a prefix stop matching we should only loose the first char, not the whole `current_word`